### PR TITLE
v3.03 - Waypoint Lock recipe fix

### DIFF
--- a/changelog_v3-02.log
+++ b/changelog_v3-02.log
@@ -1,4 +1,0 @@
-## Changes:
-
-## Fixes:
-- Portal Horn only showing one self in the menu when using it

--- a/changelog_v3-03.log
+++ b/changelog_v3-03.log
@@ -1,0 +1,4 @@
+## Changes:
+
+## Fixes:
+- The Waypoint Lock can be crafted with either an Iron Ingot or an Iron Nugget, instead of an Iron Ingot AND an Iron Nugget

--- a/data/wawo/recipe/crafting_shapeless/waypoint_lock.json
+++ b/data/wawo/recipe/crafting_shapeless/waypoint_lock.json
@@ -2,10 +2,8 @@
   "type": "minecraft:crafting_shapeless",
   "category": "misc",
   "ingredients": [
-    [
-      "minecraft:iron_ingot",
-      "minecraft:iron_nugget"
-    ]
+    "minecraft:iron_ingot",
+    "minecraft:iron_nugget"
   ],
   "result": {
     "id": "minecraft:music_disc_5",


### PR DESCRIPTION
The Waypoint Lock's recipe was incorrectly set to either an Iron Ingot or an Iron Nugget, instead of an Iron Ingot AND an Iron Nugget