### PR TITLE
v3.03 - Compasses and Recovery Compasses recipe fix

### DIFF
--- a/changelog_v3-03.log
+++ b/changelog_v3-03.log
@@ -2,3 +2,4 @@
 
 ## Fixes:
 - The Waypoint Lock can be crafted with either an Iron Ingot or an Iron Nugget, instead of an Iron Ingot AND an Iron Nugget
+- All Compasses and Recovery Compasses can be crafted with either a mineral or a Compass/Recovery Compass

--- a/data/wawo/recipe/crafting_shapeless/compass/amethyst_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/amethyst_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:amethyst_shard"
-    ]
+    "minecraft:compass",
+    "minecraft:amethyst_shard"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/copper_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/copper_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:copper_ingot"
-    ]
+    "minecraft:compass",
+    "minecraft:copper_ingot"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/diamond_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/diamond_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:diamond"
-    ]
+    "minecraft:compass",
+    "minecraft:diamond"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/emerald_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/emerald_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:emerald"
-    ]
+    "minecraft:compass",
+    "minecraft:emerald"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/golden_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/golden_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:gold_ingot"
-    ]
+    "minecraft:compass",
+    "minecraft:gold_ingot"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/lapis_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/lapis_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:lapis_lazuli"
-    ]
+    "minecraft:compass",
+    "minecraft:lapis_lazuli"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/quartz_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/quartz_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:quartz"
-    ]
+    "minecraft:compass",
+    "minecraft:quartz"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/compass/resin_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/compass/resin_compass.json
@@ -3,10 +3,8 @@
   "group": "compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:compass",
-      "minecraft:resin_clump"
-    ]
+    "minecraft:compass",
+    "minecraft:resin_clump"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/amethyst_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/amethyst_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:amethyst_shard"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:amethyst_shard"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/copper_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/copper_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:copper_ingot"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:copper_ingot"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/diamond_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/diamond_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:diamond"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:diamond"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/emerald_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/emerald_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:emerald"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:emerald"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/golden_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/golden_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:gold_ingot"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:gold_ingot"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/lapis_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/lapis_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:lapis_lazuli"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:lapis_lazuli"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/quartz_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/quartz_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:quartz"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:quartz"
   ],
   "result": {
     "components": {

--- a/data/wawo/recipe/crafting_shapeless/recovery_compass/resin_recovery_compass.json
+++ b/data/wawo/recipe/crafting_shapeless/recovery_compass/resin_recovery_compass.json
@@ -3,10 +3,8 @@
   "group": "recovery_compass",
   "category": "equipment",
   "ingredients": [
-    [
-      "minecraft:recovery_compass",
-      "minecraft:resin_clump"
-    ]
+    "minecraft:recovery_compass",
+    "minecraft:resin_clump"
   ],
   "result": {
     "components": {


### PR DESCRIPTION
All Compasses and Recovery Compasses recipes were incorrectly set to either a material or a Compass/Recovery Compass, instead of both